### PR TITLE
В воркфлоу Bump version повышать версию на определенный уровень

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/nice-pea/npchat/issues/129
-Your prepared branch: issue-129-6472a77b
-Your prepared working directory: /tmp/gh-issue-solver-1759438903977
-Your forked repository: konard/npchat
-Original repository (upstream): nice-pea/npchat
-
-Proceed.


### PR DESCRIPTION
## Решение

Исправлен воркфлоу `Bump version` для строгого соблюдения уровня повышения версии, переданного во входном параметре `level`, независимо от содержания комментариев коммитов.

### Изменения

1. **Удалены токены для поиска в комментариях**: Удалены параметры `MAJOR_STRING_TOKEN`, `MINOR_STRING_TOKEN`, `PATCH_STRING_TOKEN` и `NONE_STRING_TOKEN`, которые были установлены в значение `_` (символ подчёркивания).

2. **Причина проблемы**: Наличие символа `_` в комментариях коммитов приводило к автоматическому повышению версии на уровень major, игнорируя входной параметр `level`.

3. **Результат**: Теперь уровень повышения версии определяется исключительно параметром `DEFAULT_BUMP`, который соответствует выбранному пользователем значению `inputs.level` (patch, minor или major).

### Файлы

- `.github/workflows/bump-version.yml` - обновлён workflow

Fixes #129

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Чистка
  - Упрощена конфигурация процесса автоматического повышения версии в CI: удалены лишние строковые токены из шага. Поведение шага и остальные переменные сохранены без изменений. Это снижает сложность настройки и потенциальные точки ошибок.
- Прочее
  - Нет влияния на пользовательский функционал, выпускные артефакты и процесс версионирования; всё продолжает работать как прежде.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->